### PR TITLE
Styles: Add vertical margin between navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@ h1 {
   cursor: pointer;
   font-family: CMU serif;
    color: white;
+  margin-bottom: 4px;
 }
 
 .btn:hover {


### PR DESCRIPTION
This PR adds some vertical margin between the navigation buttons, when they start wrapping in smaller layouts
![image](https://user-images.githubusercontent.com/1216762/119270041-9b0e2b00-bbaf-11eb-9bcb-6ddfb27554d5.png)
